### PR TITLE
fix(config): tags menu url must have leading slash

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,7 +68,7 @@ enableGitInfo = true
 
 [[menu.main]]
     name = "Tags"
-    url = "tags"
+    url = "tags/"
     weight = 3
 
 [deployment]


### PR DESCRIPTION
The leading slash is needed in order for the lambda@edge function
to properly rewrite the URL.